### PR TITLE
Add squash-merge functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,19 @@ List all open pull requests: `git pr list`, or list only yours with `git pr list
 ### Merge Command
 
 Merge a pull request: `git pr merge NUMBER`
+
 ![image](https://user-images.githubusercontent.com/464795/130376573-d7d6ea25-3b34-4b15-84df-1ca30cd94f89.png)
+
+### Squash Command
+
+Squash a pull request: `git pr squash NUMBER`
+
+The squash command collapses all commits from the pull branch into a single commit and puts that commit straight onto the base branch without doing an explicit merge.
+
+Here's what the history looks like when you use `squash` vs `merge`.
+
+![image](https://user-images.githubusercontent.com/464795/130379156-1b6f19fd-075b-4899-92e9-29df49b0fb73.png)
+
 
 ## Repo configuration
 
@@ -57,6 +69,11 @@ Below are all the options
 [merge]
 # Commit message format vars: TITLE, NUMBER, AUTHOR_NAME, AUTHOR_USERNAME
 merge_msg_format = Merge: {TITLE} (#{NUMBER})
+
+[squash]
+squash_msg_format = {TITLE} (#{NUMBER})
+# Enable usage of the `git pr squash` command
+squash_cmd_enabled = True
 ```
 
 # Development

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Below are all the options
 [merge]
 # Commit message format vars: TITLE, NUMBER, AUTHOR_NAME, AUTHOR_USERNAME
 merge_msg_format = Merge: {TITLE} (#{NUMBER})
+# Enable single-commit pulls to be squashed instead of merging, even when explicitly using the merge command
+always_squash_single_commit_pulls = True
 
 [squash]
 squash_msg_format = {TITLE} (#{NUMBER})

--- a/src/git_pr_linear_merge/cfg.py
+++ b/src/git_pr_linear_merge/cfg.py
@@ -20,6 +20,7 @@ def write_default_config(auth_token):
 class MergeConfig:
     def __init__(self, config):
         self.merge_msg_format = config.get('merge', 'merge_msg_format', fallback=r'Merge: {TITLE} (#{NUMBER})')
+        self.always_squash_single_commit_pulls = config.getboolean('merge', 'always_squash_single_commit_pulls', fallback=True)
 
         self.squash_msg_format = config.get('squash', 'squash_msg_format', fallback=r'{TITLE} (#{NUMBER})')
         self.squash_cmd_enabled = config.getboolean('squash', 'squash_cmd_enabled', fallback=True)

--- a/src/git_pr_linear_merge/cfg.py
+++ b/src/git_pr_linear_merge/cfg.py
@@ -20,3 +20,6 @@ def write_default_config(auth_token):
 class MergeConfig:
     def __init__(self, config):
         self.merge_msg_format = config.get('merge', 'merge_msg_format', fallback=r'Merge: {TITLE} (#{NUMBER})')
+
+        self.squash_msg_format = config.get('squash', 'squash_msg_format', fallback=r'{TITLE} (#{NUMBER})')
+        self.squash_cmd_enabled = config.getboolean('squash', 'squash_cmd_enabled', fallback=True)

--- a/src/git_pr_linear_merge/main.py
+++ b/src/git_pr_linear_merge/main.py
@@ -200,6 +200,8 @@ def merge_command(merge_with_squash, git_repo, github_repo, pull_number, merge_c
         undo_stack.append(undo_pr_merge_action)
 
         num_commits_on_branch = len(list(git_repo.iter_commits(f'{pull.base.ref}...{pull.head.ref}@{{u}}')))
+        if num_commits_on_branch == 1 and merge_config.always_squash_single_commit_pulls:
+            merge_with_squash = True
 
         commit_msg_format = merge_config.squash_msg_format if merge_with_squash else merge_config.merge_msg_format
         merge_msg = commit_msg_format.format(


### PR DESCRIPTION
Adds a new "squash" command that collapses all the commits in the pull request into a single commit and omits an explicit merge commit.

Also uses squash behavior for single-commit pulls by default.

Resolves #1